### PR TITLE
Fix reset button by clearing timers

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 
 "use client";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 // カード型
 type Card = {
@@ -19,9 +19,12 @@ export default function Page() {
   const [lockBoard, setLockBoard] = useState(false);
   const [message, setMessage] = useState("カードをめくってね！");
   const [gameOver, setGameOver] = useState(false);
+  const timeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
 
   // 初期化 & リセット
   const buildDeck = () => {
+    timeoutsRef.current.forEach(clearTimeout);
+    timeoutsRef.current = [];
     // 8枚(4ペア) + ジョーカー1枚 = 9枚
     const normals = pairSymbols.flatMap((s) => [
       { symbol: s, isJoker: false },
@@ -78,7 +81,7 @@ export default function Page() {
 
       if (first.symbol === second.symbol) {
         // 揃った！
-        setTimeout(() => {
+        const timeoutId = setTimeout(() => {
           setCards((current) => {
             const c = current.slice();
             c[firstIndex] = { ...c[firstIndex], isMatched: true };
@@ -95,10 +98,12 @@ export default function Page() {
           } else {
             setMessage("✅ 揃いました！続けてね");
           }
+          timeoutsRef.current = timeoutsRef.current.filter((id) => id !== timeoutId);
         }, 250);
+        timeoutsRef.current.push(timeoutId);
       } else {
         // ちがう → 自動で裏へ
-        setTimeout(() => {
+        const timeoutId = setTimeout(() => {
           setCards((current) => {
             const c = current.slice();
             c[firstIndex] = { ...c[firstIndex], isFlipped: false };
@@ -109,7 +114,9 @@ export default function Page() {
           setSecondIndex(null);
           setLockBoard(false);
           setMessage("❌ ちがいました。もう一度！");
+          timeoutsRef.current = timeoutsRef.current.filter((id) => id !== timeoutId);
         }, 700);
+        timeoutsRef.current.push(timeoutId);
       }
     }
   };
@@ -149,7 +156,6 @@ export default function Page() {
         <button
           onClick={buildDeck}
           className="px-3 py-1 rounded-2xl border shadow-sm disabled:opacity-50"
-          disabled={lockBoard}
         >
           リセット
         </button>

--- a/docs/analysis.md
+++ b/docs/analysis.md
@@ -1,0 +1,47 @@
+# Card Game Codebase Analysis
+
+## Overview
+This repository contains a small Next.js application that implements a nine-card memory matching game with a Joker. The entire game logic lives inside the default page component (`app/page.tsx`), which is rendered as a client component. The UI is styled primarily with Tailwind CSS utilities defined in `app/globals.css` and `tailwind.config.ts`.
+
+## Application Structure
+- **Next.js App Router**: The app uses the App Router structure (`app/` directory). `app/layout.tsx` defines the root layout and metadata, while `app/page.tsx` hosts the interactive game.
+- **Client Component**: `app/page.tsx` begins with `"use client";`, which enables hooks such as `useState` and `useEffect` for client-side interactivity.
+- **Styling**: Global styles live in `app/globals.css`. Component-level styling uses Tailwind utility classes configured in `tailwind.config.ts`.
+
+## Game Logic (`app/page.tsx`)
+- **State**
+  - `cards`: Array of card objects containing `id`, `symbol`, `isJoker`, `isFlipped`, and `isMatched` fields.
+  - `firstIndex`, `secondIndex`: Track which cards are currently flipped for matching.
+  - `lockBoard`: Prevents input while animations or evaluations are pending.
+  - `message`: Feedback text shown to the player.
+  - `gameOver`: Indicates a Joker reveal or completion of all pairs.
+- **Deck Construction**
+  - The `buildDeck` function generates eight normal cards (four pairs) plus a Joker, assigns sequential IDs, and shuffles them with `Array.sort(() => Math.random() - 0.5)`.
+  - Resets all stateful flags and messages.
+- **Lifecycle**
+  - `useEffect` runs `buildDeck` once when the component mounts to initialize the game.
+- **Interaction**
+  - `handleClick` guards against invalid actions (board locked, game over, already matched/flipped cards).
+  - Flipping the Joker ends the game immediately.
+  - For normal cards, the handler manages the first and second selections, compares symbols, and updates match state.
+  - `setTimeout` is used for delayed updates: quick confirmation for matches and longer delay before hiding mismatched cards.
+  - When all eight non-Joker cards are matched, the message changes to a victory notification.
+- **UI Rendering**
+  - The board is a 3×3 grid of buttons whose labels reveal card symbols when flipped or matched.
+  - Accessibility considerations include `aria-label` identifiers for cards and disabled states to prevent invalid interactions.
+  - A reset button re-runs `buildDeck`, disabled while the board is locked.
+  - Additional educational notes are provided in a `<details>` section for beginners.
+
+## Potential Improvements
+- Extract the card grid into a dedicated component to simplify `page.tsx`.
+- Introduce animations (e.g., via CSS transitions) for flipping feedback.
+- Replace the simple shuffle with a Fisher–Yates implementation to avoid bias.
+- Add unit tests for deck construction and matching logic using a framework like Jest or Vitest.
+- Localize strings or move them into a constants file for easier maintenance.
+
+## Running the Project
+```bash
+npm install
+npm run dev
+```
+Then visit `http://localhost:3000` to play the game.


### PR DESCRIPTION
## Summary
- ensure pending flip timers are cleared when rebuilding the deck so the reset button works reliably
- allow resetting even while the board is locked or after a joker flip by keeping the button enabled

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcd17b1d3083229f2772feaae05245